### PR TITLE
Use default optimizations when AT_SECURE

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -262,7 +262,8 @@ void OPENSSL_cpuid_setup(void)
 
     OPENSSL_armcap_P = 0;
 
-    if ((e = getenv("OPENSSL_armcap"))) {
+    if (OPENSSL_issetugid() == 0
+	&& (e = getenv("OPENSSL_armcap"))) {
         OPENSSL_armcap_P = (unsigned int)strtoul(e, NULL, 0);
         return;
     }

--- a/crypto/cpuid.c
+++ b/crypto/cpuid.c
@@ -103,7 +103,8 @@ void OPENSSL_cpuid_setup(void)
         return;
 
     trigger = 1;
-    if ((env = ossl_getenv("OPENSSL_ia32cap")) != NULL) {
+    if (OPENSSL_issetugid() == 0
+	&& (env = ossl_getenv("OPENSSL_ia32cap")) != NULL) {
         int off = (env[0] == '~') ? 1 : 0;
 
         vec = ossl_strtouint64(env + off);

--- a/crypto/info.c
+++ b/crypto/info.c
@@ -49,7 +49,7 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
                  (unsigned long long)OPENSSL_ia32cap_P[1] << 32,
                  (unsigned long long)OPENSSL_ia32cap_P[2] |
                  (unsigned long long)OPENSSL_ia32cap_P[3] << 32);
-    if ((env = getenv("OPENSSL_ia32cap")) != NULL)
+    if ((env = ossl_safe_getenv("OPENSSL_ia32cap")) != NULL)
         BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
                      sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),
                      " env:%s", env);
@@ -58,7 +58,7 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
 
     BIO_snprintf(ossl_cpu_info_str, sizeof(ossl_cpu_info_str),
                  CPUINFO_PREFIX "OPENSSL_armcap=0x%x", OPENSSL_armcap_P);
-    if ((env = getenv("OPENSSL_armcap")) != NULL)
+    if ((env = ossl_safe_getenv("OPENSSL_armcap")) != NULL)
         BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
                      sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),
                      " env:%s", env);
@@ -94,7 +94,7 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
                  OPENSSL_s390xcap_P.kma[0], OPENSSL_s390xcap_P.kma[1],
                  OPENSSL_s390xcap_P.pcc[0], OPENSSL_s390xcap_P.pcc[1],
                  OPENSSL_s390xcap_P.kdsa[0], OPENSSL_s390xcap_P.kdsa[1]);
-    if ((env = getenv("OPENSSL_s390xcap")) != NULL)
+    if ((env = ossl_safe_getenv("OPENSSL_s390xcap")) != NULL)
         BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
                      sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),
                      " env:%s", env);

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -148,7 +148,8 @@ void OPENSSL_cpuid_setup(void)
         return;
     trigger = 1;
 
-    if ((e = getenv("OPENSSL_ppccap"))) {
+    if (OPENSSL_issetugid() == 0
+	&& (e = getenv("OPENSSL_ppccap"))) {
         OPENSSL_ppccap_P = strtoul(e, NULL, 0);
         return;
     }

--- a/crypto/riscvcap.c
+++ b/crypto/riscvcap.c
@@ -88,7 +88,8 @@ void OPENSSL_cpuid_setup(void)
         return;
     trigger = 1;
 
-    if ((e = getenv("OPENSSL_riscvcap"))) {
+    if (OPENSSL_issetugid() == 0
+	&& (e = getenv("OPENSSL_riscvcap"))) {
         parse_env(e);
     }
 

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -171,7 +171,11 @@ void OPENSSL_cpuid_setup(void)
     }
 #endif
 
-    env = getenv("OPENSSL_s390xcap");
+    if(OPENSSL_issetugid() == 0)
+	env = getenv("OPENSSL_s390xcap");
+    else
+	env = NULL
+
     if (env != NULL) {
         if (!parse_env(&cap, &cex))
             env = NULL;

--- a/crypto/sparcv9cap.c
+++ b/crypto/sparcv9cap.c
@@ -93,7 +93,8 @@ void OPENSSL_cpuid_setup(void)
         return;
     trigger = 1;
 
-    if ((e = getenv("OPENSSL_sparcv9cap"))) {
+    if (OPENSSL_issetugid() == 0
+	&& (e = getenv("OPENSSL_sparcv9cap"))) {
         OPENSSL_sparcv9cap_P[0] = strtoul(e, NULL, 0);
         if ((e = strchr(e, ':')))
             OPENSSL_sparcv9cap_P[1] = strtoul(e + 1, NULL, 0);


### PR DESCRIPTION
As mentioned in #5860, OPENSSL_ia32cap (and other CPU environment variables), are taken from getenv instead of secure_getenv. This allows us to cause invalid optimizations to be taken in privileged program (e.g. suid/setcap) using openssl.

For a quick demo, imagine the following.
```
cp /usr/bin/openssl openssl_local
sudo chown root openssl_local
sudo chmod u+s openssl_local
echo test | ./openssl_local dgst -sha256 # works fine
echo test | OPENSSL_ia32cap=0xffffffffffffffff:0xffffffffffffffff ~/openssl_local dgst -sha256 # SIGILL on older intel CPUs
```
Any binary which links to openssl allows the user to pick the CPU optimizations used. This is great, however, in the case of AT_SECURE programs, I think it's a security concern.

For a concrete example, take a look at ssh-keysign, which is setuid root. Since ssh-keysign uses openssl, it will use OPENSSL_ia32cap.
```
$ gdb /usr/lib/openssh/ssh-keysign
(gdb) b getenv
Breakpoint 1 at 0x5310
(gdb) run
Starting program: /usr/bin/ssh-agent
Breakpoint 1, __GI_getenv (name=0x7fc9364ddf53 "OPENSSL_ia32cap") at ./stdlib/getenv.c:34
(gdb)
```
ssh-keysign appears to be internal to ssh and does not have much documentation, and so I have not been able to create a PoC that would crash ssh-keysign. Another binary which reads OPENSSL_ia32cap is ssh-agent, which is setgid as user "_ssh".

This pull request prevents openssl from getting CPU information from the user when the program runs with more privileges than the current user. OPENSSL_ia32cap (and the other CPU optimization variables) still work perfectly fine, during normal openssl use cases.

I was able to test that this prevents SIGILL for suid programs on x86. I was not able to directly test my changes for the non-intel CPUs, since I don't have a non x86 environment setup. But they should be equivalent to the x86 changes.